### PR TITLE
changed to nth-of-type for iOS 8 bug

### DIFF
--- a/sass/susy/language/susy/_gallery.scss
+++ b/sass/susy/language/susy/_gallery.scss
@@ -8,7 +8,7 @@
 // - [$selector]  : child | of-type
 @mixin gallery(
   $span,
-  $selector: child
+  $selector: of-type
 ) {
   $inspect    : $span;
   $span       : parse-span($span);


### PR DESCRIPTION
:nth-child on iOS 8 does not work, changing to :nth-of-type makes this work correctly, more info here: http://stackoverflow.com/questions/26032513/ios8-safari-after-a-pushstate-the-nth-child-selectors-not-works