### PR TITLE
Use sass-loader's shortcut to node_modules

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -181,7 +181,7 @@ Start using Susy:
 .. code-block:: sass
 
     /* app.scss */
-    @import "node_modules/susy/sass/susy";
+    @import "~susy/sass/susy";
 
 
 Manual Start

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -160,13 +160,13 @@ Install using npm:
 
 .. code-block:: bash
 
-    npm install susy --save
+    npm install susy sass-loader --save-dev
 
 
-Make sure you have `sass-loader <https://github.com/jtangelder/sass-loader>`_ installed and enabled in your `webpack` configuration:
+Make sure you have `sass-loader <https://github.com/jtangelder/sass-loader>`_ enabled in your `webpack` configuration:
 
 .. code-block:: js
-    
+
     // webpack.config.js
     loaders: [
       {


### PR DESCRIPTION
Use a webpack sass-loader way to specify the location of susy, but without specifying the location of node_modules directly

https://github.com/jtangelder/sass-loader#imports is the doc from sass-loader that describes it