### PR TITLE
sass-rails 5 is no longer in beta

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,13 +27,13 @@ Simple Install
 Bundler or Rails
 ----------------
 
-.. warning:: In order to use Susy 2 with Rails you must update your Gemfile to use sass-rails ~> 5.0.0.beta1. This is because Susy 2 requires Sass >= 3.3 whilst Rails 4.1 and below include a version of sass-rails which does not support Sass 3.3. As you can see the sass-rails requirement is still in beta so proceed with a drink in hand.
+.. warning:: In order to use Susy 2 with Rails you must update your Gemfile to use sass-rails ~> 5.0.0. This is because Susy 2 requires Sass >= 3.3 whilst Rails 4.1 and below include a version of sass-rails which does not support Sass 3.3.
 
 .. code-block:: ruby
 
   # Gemfile
   # gem 'sass-rails', '~> 4.0.3'
-  gem 'sass-rails', '~> 5.0.0.beta1'
+  gem 'sass-rails', '~> 5.0.0'
   gem 'susy'
 
   # If you want Compass:


### PR DESCRIPTION
I know there's even newer versions than 5.0.0, but I assume you don't want to update the version after every release, so I stuck with 5.0.0 since that's the minimum.